### PR TITLE
Disable Disqus comments for post previews

### DIFF
--- a/post.hbs
+++ b/post.hbs
@@ -75,6 +75,7 @@
         </footer>
 
         <section class="post-comments">
+        {{#if published_at}}
             <div id="disqus_thread"></div>
             <script type="text/javascript">
                 /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
@@ -89,6 +90,11 @@
             </script>
             <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
             <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
+        {{else}}
+            <div class="comments-disabled">
+                <p>Comments are disabled for post previews.</p>
+            </div>
+        {{/if}}
         </section>
 
         {{!--


### PR DESCRIPTION
It irritated me that my not-yet-published posts had their own Disqus thread - and were being 'suggested' as content from comment sections of published pages, because Disqus was being loaded during post preview.  
If the Publish Date (in Post Settings) is empty during preview - which it is by default - then this change means Disqus comments aren't loaded during Preview... but only when the post is actually published.