### PR TITLE
Disable Disqus comments for static page previews

### DIFF
--- a/page.hbs
+++ b/page.hbs
@@ -67,6 +67,7 @@
         </footer>
 
         <section class="post-comments">
+        {{#if published_at}}
             <div id="disqus_thread"></div>
             <script type="text/javascript">
                 /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
@@ -81,6 +82,11 @@
             </script>
             <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
             <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
+        {{else}}
+            <div class="comments-disabled">
+                <p>Comments are disabled for page previews.</p>
+            </div>
+        {{/if}}
         </section>
 
     {{/post}}


### PR DESCRIPTION
Same method as for posts - i.e. Published Date must be empty for the previewed page (which it is by default) for the comments to be disabled.