### PR TITLE
ghost-1.1.0 - cover_image

### DIFF
--- a/author.hbs
+++ b/author.hbs
@@ -7,8 +7,8 @@
 {{#author}}
     <section class="author-profile">
         <div class="author-cover" {{#if cover_image}}style="background-image: url({{cover_image}}){{/if}}">
-            {{#if image}}
-                <img class="author-image" alt="{{name}}'s Picture" src="{{image}}">
+            {{#if profile_image}}
+                <img class="author-image" alt="{{name}}'s Picture" src="{{img_url profile_image}}">
             {{/if}}
         </div>
 

--- a/author.hbs
+++ b/author.hbs
@@ -6,7 +6,7 @@
 {{!-- Everything inside the #author tags pulls data from the author --}}
 {{#author}}
     <section class="author-profile">
-        <div class="author-cover" {{#if cover}}style="background-image: url({{cover}}){{/if}}">
+        <div class="author-cover" {{#if cover_image}}style="background-image: url({{cover_image}}){{/if}}">
             {{#if image}}
                 <img class="author-image" alt="{{name}}'s Picture" src="{{image}}">
             {{/if}}


### PR DESCRIPTION
Handle cover changing to cover_image. The theme importer didn't seem to complain previously.

See: https://github.com/TryGhost/Ghost/commit/76bd4fdef6b681e8b0d7a000b166df6f6697979a
